### PR TITLE
fixed wicket multipart form submit

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootWebApplication.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootWebApplication.java
@@ -3,6 +3,8 @@ package com.giffing.wicket.spring.boot.starter.app;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.servlet.Servlet;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.RuntimeConfigurationType;
 import org.apache.wicket.authroles.authentication.AbstractAuthenticatedWebSession;
@@ -13,7 +15,10 @@ import org.apache.wicket.spring.injection.annot.SpringComponentInjector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.DispatcherServlet;
 
 import com.giffing.wicket.spring.boot.starter.WicketProperties;
 import com.giffing.wicket.spring.boot.starter.configuration.WicketApplicationInitConfiguration;
@@ -69,4 +74,23 @@ public class WicketBootWebApplication extends AuthenticatedWebApplication {
 	public RuntimeConfigurationType getConfigurationType() {
 		return wicketProperties.getConfigurationType();
 	}
+	
+	/*
+	 * fixes multipart form sumbit
+	 */
+	@Bean
+	Servlet dispatcherServlet(){
+		return new DispatcherServlet();
+	}
+	
+	@Bean
+	ServletRegistrationBean servletRegistrationBean(){
+		ServletRegistrationBean reg = new ServletRegistrationBean();
+		reg.setServlet(dispatcherServlet());
+		reg.addUrlMappings("/**");
+		return reg;
+	}
+	/*
+	 * end of multipart form submit fix
+	 */
 }


### PR DESCRIPTION
When using wicket with spring boot, there is a problem with multipart forms.
If a form with enctype multipart has one or more submit links, the onSubmit() methods of these links is not called at all. Only the onSubmit() mehtod of the form itself is called.

I created a gist with a small test page to reproduce the error
https://gist.github.com/pingunaut/0b78a8947d2b07ae976e

It costed hours to figure out where the problem is coming from. It is somehow caused by the default spring mvc dispatcher servlet.
Spring docs show how to switch off default behavior:
http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-switch-off-the-spring-mvc-dispatcherservlet

With the fix implemented in this pull request, the multipart form submit problem is solved.

WATCH OUT: i was not able to test complex spring security and other spring integration side effects but at the first but first tests prove that everything continues working fine

Thanks for sharing your lib :+1: 
