### PR TITLE
Disabled gpg-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.5</version>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>				
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>


### PR DESCRIPTION
To enable, use `-Dgpg.skip=false` on the maven command line.

(the usual `mvn clean install` should **not** sign the artifact by default)