### PR TITLE
Wicket filter registration should respect configured filter-mapping-param

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
@@ -61,7 +61,7 @@ public class WicketWebInitializer implements ServletContextInitializer {
 		filter.setInitParameter("applicationBean", beanNamesForType[0]);
 
 		filter.setInitParameter(WicketFilter.FILTER_MAPPING_PARAM, props.getFilterMappingParam());
-		filter.addMappingForUrlPatterns(null, false, "/*");
+		filter.addMappingForUrlPatterns(null, false, props.getFilterMappingParam());
 
 		Map<String, String> initParameters = props.getInitParameters();
 		for (Entry<String, String> initParam : initParameters.entrySet()) {


### PR DESCRIPTION
`WicketWebInitializer` accepts a parameter `wicket.web.servlet.filter-mapping-param` and will correctly set it as parameter to the Wicket filter.
However, it afterwards always registers the filter to the context root without respecting the passed parameter. This causes problems if there are other servlets in your web application (e.g. REST services).

This pull request fixes the issue by also using the `wicket.web.servlet.filter-mapping-param` setting in the filter mapping.