### PR TITLE
allows wicket filter to handle 404 errors

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
@@ -1,8 +1,10 @@
 package com.giffing.wicket.spring.boot.starter.web;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -61,7 +63,7 @@ public class WicketWebInitializer implements ServletContextInitializer {
 		filter.setInitParameter("applicationBean", beanNamesForType[0]);
 
 		filter.setInitParameter(WicketFilter.FILTER_MAPPING_PARAM, props.getFilterMappingParam());
-		filter.addMappingForUrlPatterns(null, false, props.getFilterMappingParam());
+		filter.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, props.getFilterMappingParam());
 
 		Map<String, String> initParameters = props.getInitParameters();
 		for (Entry<String, String> initParam : initParameters.entrySet()) {


### PR DESCRIPTION
In one of our projects we wanted to customize all the error pages.
The documentation states that this is possible with the follwing three annotations:
```
@WicketExpiredPage
@WicketAccessDeniedPage
@WicketInternalErrorPage
```
The problem we faced is that requests which resulted in a 404 did not pass trough the wicket filter.
In this pull request we configure the wicket filter to handle all requests. With this in place our error page gets correctly called.

I could also imagine to make this configurable to only handle REQUEST and ERROR and not all DispatcherTypes but in our case we just added all.

An other workaround we found is to just use the following snippeet in the `init()` method of our `WicketBootSecuredWebApplication`:
```
getWicketFilter().getFilterConfig().getServletContext().getFilterRegistration(WicketWebInitializer.WICKET_FILTERNAME).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, props.getFilterMappingParam());
```
But this just adds an other mapping which is not exactly the proper way and prone to create issues if it gets added at the wrong place.
FYI: we used it in version 1.x and not 2.x