### PR TITLE
spring-boot-starter-parent 1.5.14 / wicket-webjars 0.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 			<dependency>
 				<groupId>de.agilecoders.wicket.webjars</groupId>
 				<artifactId>wicket-webjars</artifactId>
-				<version>0.5.5</version>
+				<version>0.5.6</version>
 			</dependency>
 			<!-- Wicket datastore dependencies -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.10.RELEASE</version>
+		<version>1.5.14.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Hi @MarcGiffing 

This pull request takes care of bumping the spring-boot-starter parent to the currently released 1.5.14 version. With it, I also gave wicket-webjars a lift.

Are there any plans from your side to move the project to spring boot 2.x?

Thanks and cheers
Urs