### PR TITLE
Upgrade to Wicket v9 M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -56,9 +56,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<apache-shiro.version>1.4.0</apache-shiro.version>
-		<wicket.version>8.4.0</wicket.version>
+		<wicket.version>9.0.0-M3</wicket.version>
+		<wicketstuff.version>9.0.1-M3</wicketstuff.version>
 	</properties>
 
 	<dependencyManagement>
@@ -104,12 +105,12 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-annotation</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-htmlcompressor</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency> <!-- required for the wicketstuff-htmlcompressor -->
 				<groupId>com.yahoo.platform.yui</groupId>
@@ -119,27 +120,27 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-serializer-kryo2</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-serializer-fast2</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-restannotations</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-restannotations-json</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-springreference</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff.htmlvalidator</groupId>
@@ -149,7 +150,7 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-jamon</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 
 			<!-- Wicket other dependencies -->
@@ -161,33 +162,33 @@
 			<dependency>
 				<groupId>de.agilecoders.wicket.webjars</groupId>
 				<artifactId>wicket-webjars</artifactId>
-				<version>2.0.8</version>
+				<version>3.0.0-M3</version>
 			</dependency>
 			<!-- Wicket datastore dependencies -->
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-common</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-cassandra</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-hazelcast</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-memcached</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-redis</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<!-- Wicket websockets -->
 			<dependency>
@@ -210,7 +211,7 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-shiro</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.shiro</groupId>

--- a/wicket-spring-boot-context/src/main/java/com/giffing/wicket/spring/boot/context/extensions/types/TypeParser.java
+++ b/wicket-spring-boot-context/src/main/java/com/giffing/wicket/spring/boot/context/extensions/types/TypeParser.java
@@ -1,9 +1,9 @@
 package com.giffing.wicket.spring.boot.context.extensions.types;
 
 import org.apache.wicket.util.lang.Bytes;
-import org.apache.wicket.util.time.Duration;
 
 import com.giffing.wicket.spring.boot.context.exceptions.WicketSpringBootException;
+import java.time.Duration;
 
 public class TypeParser {
 
@@ -24,15 +24,15 @@ public class TypeParser {
 	public static Duration parse(Long time, DurationUnit durationUnit){
 		switch(durationUnit){
 		case DAYS:
-			return Duration.days(time);
+			return Duration.ofDays(time);
 		case HOURS:
-			return Duration.hours(time);
+			return Duration.ofHours(time);
 		case MILLISECONDS:
-			return Duration.milliseconds(time);
+			return Duration.ofMillis(time);
 		case MINUTES:
-			return Duration.minutes(time);
+			return Duration.ofMillis(time);
 		case SECONDS:
-			return Duration.seconds(time);
+			return Duration.ofSeconds(time);
 		}
 		
 		throw new WicketSpringBootException("Could not parse time with duration unit " + time + " " + durationUnit);

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/jpa/support/CustomSimpleJpaRepository.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/jpa/support/CustomSimpleJpaRepository.java
@@ -8,7 +8,6 @@ import javax.persistence.TypedQuery;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.repository.NoRepositoryBean;

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/customer/specs/CustomerSpecs.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/customer/specs/CustomerSpecs.java
@@ -1,10 +1,5 @@
 package com.giffing.wicket.spring.boot.example.repository.services.customer.specs;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-
 import org.springframework.data.jpa.domain.Specification;
 
 import com.giffing.wicket.spring.boot.example.model.Customer;

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/html/modal/YesNoPanel.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/html/modal/YesNoPanel.java
@@ -1,10 +1,8 @@
 package com.giffing.wicket.spring.boot.example.web.html.modal;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
-import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/pages/customers/CustomerListPage.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/pages/customers/CustomerListPage.java
@@ -15,7 +15,6 @@ import org.apache.wicket.extensions.markup.html.repeater.data.table.PropertyColu
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterForm;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilterToolbar;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.FilteredPropertyColumn;
-import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.TextField;

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/security/WicketWebSecurityAdapterConfig.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/web/security/WicketWebSecurityAdapterConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 /**

--- a/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/WicketBaseIntTest.java
+++ b/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/WicketBaseIntTest.java
@@ -1,13 +1,6 @@
 package com.giffing.wicket.spring.boot.example.web;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.servlet.SessionTrackingMode;
-
 import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.protocol.http.mock.MockServletContext;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.Before;

--- a/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/WicketBaseTest.java
+++ b/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/WicketBaseTest.java
@@ -1,13 +1,6 @@
 package com.giffing.wicket.spring.boot.example.web;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.servlet.SessionTrackingMode;
-
 import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.protocol.http.mock.MockServletContext;
 import org.apache.wicket.util.tester.FormTester;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.Before;

--- a/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/pages/customers/CustomerListIntTest.java
+++ b/wicket-spring-boot-starter-example/src/test/java/com/giffing/wicket/spring/boot/example/web/pages/customers/CustomerListIntTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.annotation.Rollback;
 
 import com.giffing.wicket.spring.boot.example.model.Customer;
 import com.giffing.wicket.spring.boot.example.repository.services.customer.CustomerRepositoryService;
-import com.giffing.wicket.spring.boot.example.repository.services.customer.filter.CustomerFilter;
 import com.giffing.wicket.spring.boot.example.repository.services.customer.filter.CustomerSort;
 import com.giffing.wicket.spring.boot.example.web.WicketBaseIntTest;
 import com.giffing.wicket.spring.boot.example.web.html.modal.YesNoModal;

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootSecuredWebApplication.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootSecuredWebApplication.java
@@ -7,7 +7,6 @@ import org.apache.wicket.Page;
 import org.apache.wicket.RuntimeConfigurationType;
 import org.apache.wicket.authroles.authentication.AbstractAuthenticatedWebSession;
 import org.apache.wicket.authroles.authentication.AuthenticatedWebApplication;
-import org.apache.wicket.authroles.authorization.strategies.role.annotations.AnnotationsRoleAuthorizationStrategy;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.spring.injection.annot.SpringComponentInjector;

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/datastore/DataStoreHttpSessionConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/datastore/DataStoreHttpSessionConfig.java
@@ -1,10 +1,7 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.core.datastore;
 
 import org.apache.wicket.DefaultPageManagerProvider;
-import org.apache.wicket.page.DefaultPageManagerContext;
-import org.apache.wicket.pageStore.IDataStore;
-import org.apache.wicket.pageStore.memory.HttpSessionDataStore;
-import org.apache.wicket.pageStore.memory.PageNumberEvictionStrategy;
+import org.apache.wicket.pageStore.IPageStore;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -15,11 +12,12 @@ import com.giffing.wicket.spring.boot.context.extensions.ApplicationInitExtensio
 import com.giffing.wicket.spring.boot.context.extensions.WicketApplicationInitConfiguration;
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketAutoConfig;
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketEndpointRepository;
+import org.wicketstuff.shiro.wicket.page.store.SessionPageStore;
 
 @ApplicationInitExtension
 @ConditionalOnProperty(prefix = DataStoreHttpSessionProperties.PROPERTY_PREFIX, value = "enabled", matchIfMissing = false)
 @EnableConfigurationProperties({ DataStoreHttpSessionProperties.class })
-@AutoConfigureAfter(HttpSessionDataStore.class)
+@AutoConfigureAfter(SessionPageStore.class)
 public class DataStoreHttpSessionConfig implements WicketApplicationInitConfiguration {
 
 	@Autowired
@@ -33,8 +31,8 @@ public class DataStoreHttpSessionConfig implements WicketApplicationInitConfigur
 
 		webApplication.setPageManagerProvider(new DefaultPageManagerProvider(webApplication) {
 			@Override
-			protected IDataStore newDataStore() {
-				return new HttpSessionDataStore(new DefaultPageManagerContext(), new PageNumberEvictionStrategy(props.getPagesNumber()));
+			protected IPageStore newSessionStore(final IPageStore pageStore) {
+				return new SessionPageStore(webApplication.getName(), props.getPagesNumber());
 			}
 		});
 		

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/datastore/DataStoreHttpSessionConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/datastore/DataStoreHttpSessionConfig.java
@@ -17,7 +17,6 @@ import org.wicketstuff.shiro.wicket.page.store.SessionPageStore;
 @ApplicationInitExtension
 @ConditionalOnProperty(prefix = DataStoreHttpSessionProperties.PROPERTY_PREFIX, value = "enabled", matchIfMissing = false)
 @EnableConfigurationProperties({ DataStoreHttpSessionProperties.class })
-@AutoConfigureAfter(SessionPageStore.class)
 public class DataStoreHttpSessionConfig implements WicketApplicationInitConfiguration {
 
 	@Autowired

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/pagestore/StoreSettingsConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/pagestore/StoreSettingsConfig.java
@@ -37,9 +37,6 @@ public class StoreSettingsConfig implements WicketApplicationInitConfiguration {
 		if (props.getFileStoreFolder() != null) {
 			storeSettings.setFileStoreFolder(new File(props.getFileStoreFolder()));
 		}
-		if (props.getInmemoryCacheSize() != null) {
-			storeSettings.setInmemoryCacheSize(props.getInmemoryCacheSize());
-		}
 		storeSettings.setMaxSizePerSession(TypeParser.parse(props.getSessionSize(), props.getSessionUnit()));
 		
 		wicketEndpointRepository.add(new WicketAutoConfig.Builder(this.getClass())

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/pagestore/StoreSettingsProperties.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/pagestore/StoreSettingsProperties.java
@@ -24,8 +24,6 @@ public class StoreSettingsProperties {
 	
 	private String fileStoreFolder;
 	
-	private Integer inmemoryCacheSize;
-	
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -56,14 +54,6 @@ public class StoreSettingsProperties {
 
 	public void setFileStoreFolder(String fileStoreFolder) {
 		this.fileStoreFolder = fileStoreFolder;
-	}
-
-	public Integer getInmemoryCacheSize() {
-		return inmemoryCacheSize;
-	}
-
-	public void setInmemoryCacheSize(Integer inmemoryCacheSize) {
-		this.inmemoryCacheSize = inmemoryCacheSize;
 	}
 
 	public Long getSessionSize() {

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/requestlogger/RequestLoggerSettingsConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/core/settings/requestlogger/RequestLoggerSettingsConfig.java
@@ -1,7 +1,6 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.core.settings.requestlogger;
 
 import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.settings.ExceptionSettings;
 import org.apache.wicket.settings.RequestLoggerSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserConfig.java
@@ -1,6 +1,7 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.external.development.devutils.diskstorebrowser;
 
 import org.apache.wicket.DefaultPageManagerProvider;
+import org.apache.wicket.devutils.pagestore.PageStorePage;
 import org.apache.wicket.markup.html.pages.BrowserInfoPage;
 import org.apache.wicket.pageStore.DiskPageStore;
 import org.apache.wicket.pageStore.IPageStore;
@@ -20,9 +21,9 @@ import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketEnd
 import java.io.File;
 
 /**
- * Mounts the {@link DiskPageStore} if the following condition matches
+ * Mounts the {@link PageStorePage} if the following condition matches
  * 
- * 1. The {@link DiskPageStore} is in the classpath
+ * 1. The {@link PageStorePage} is in the classpath
  * 
  * 2. The disk store browser page is enabled in the property (default=false)
  * 
@@ -31,7 +32,7 @@ import java.io.File;
  */
 @ApplicationInitExtension
 @ConditionalOnProperty(prefix = DiskStoreBrowserProperties.PROPERTY_PREFIX, value = "enabled", matchIfMissing = false)
-@ConditionalOnClass(value = DiskPageStore.class)
+@ConditionalOnClass(value = PageStorePage.class)
 @EnableConfigurationProperties({ DiskStoreBrowserProperties.class })
 public class DiskStoreBrowserConfig implements WicketApplicationInitConfiguration {
 

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserConfig.java
@@ -1,8 +1,12 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.external.development.devutils.diskstorebrowser;
 
-import org.apache.wicket.devutils.diskstore.DebugPageManagerProvider;
-import org.apache.wicket.devutils.diskstore.DiskStoreBrowserPage;
+import org.apache.wicket.DefaultPageManagerProvider;
+import org.apache.wicket.markup.html.pages.BrowserInfoPage;
+import org.apache.wicket.pageStore.DiskPageStore;
+import org.apache.wicket.pageStore.IPageStore;
 import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.settings.StoreSettings;
+import org.apache.wicket.util.lang.Bytes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,10 +17,12 @@ import com.giffing.wicket.spring.boot.context.extensions.WicketApplicationInitCo
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketAutoConfig;
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketEndpointRepository;
 
+import java.io.File;
+
 /**
- * Mounts the {@link DiskStoreBrowserPage} if the following condition matches
+ * Mounts the {@link DiskPageStore} if the following condition matches
  * 
- * 1. The {@link DiskStoreBrowserPage} is in the classpath
+ * 1. The {@link DiskPageStore} is in the classpath
  * 
  * 2. The disk store browser page is enabled in the property (default=false)
  * 
@@ -25,7 +31,7 @@ import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketEnd
  */
 @ApplicationInitExtension
 @ConditionalOnProperty(prefix = DiskStoreBrowserProperties.PROPERTY_PREFIX, value = "enabled", matchIfMissing = false)
-@ConditionalOnClass(value = org.apache.wicket.devutils.diskstore.DiskStoreBrowserPage.class)
+@ConditionalOnClass(value = DiskPageStore.class)
 @EnableConfigurationProperties({ DiskStoreBrowserProperties.class })
 public class DiskStoreBrowserConfig implements WicketApplicationInitConfiguration {
 
@@ -37,9 +43,16 @@ public class DiskStoreBrowserConfig implements WicketApplicationInitConfiguratio
 	
 	@Override
 	public void init(WebApplication webApplication) {
-		DebugPageManagerProvider pageManager = new DebugPageManagerProvider(webApplication);
-		webApplication.setPageManagerProvider(pageManager);
-		webApplication.mountPage(properties.getMountPage(), DiskStoreBrowserPage.class);
+		webApplication.setPageManagerProvider(new DefaultPageManagerProvider(webApplication) {
+			@Override
+			protected IPageStore newSessionStore(final IPageStore pageStore) {
+				StoreSettings storeSettings = application.getStoreSettings();
+				File fileStoreFolder = storeSettings.getFileStoreFolder();
+				Bytes maxSizePerSession = storeSettings.getMaxSizePerSession();
+				return new DiskPageStore(webApplication.getName(), fileStoreFolder, maxSizePerSession);
+			}
+		});
+		webApplication.mountPage(properties.getMountPage(), BrowserInfoPage.class);
 		
 		wicketEndpointRepository.add(new WicketAutoConfig.Builder(this.getClass())
 				.withDetail("properties", properties)

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserProperties.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserProperties.java
@@ -8,7 +8,7 @@ public class DiskStoreBrowserProperties {
 	public static final String PROPERTY_PREFIX = "wicket.external.development.devutils.diskstorebrowser";
 	
 	/**
-	 * If enabled the {@link org.apache.wicket.markup.html.pages.BrowserInfoPage} should be mounted test page.
+	 * If enabled the {@link org.apache.wicket.devutils.pagestore.PageStorePage} should be mounted test page.
 	 * 
 	 * It is required that the deployment configuration is set to DEVELOPMENT.
 	 */

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserProperties.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/external/development/devutils/diskstorebrowser/DiskStoreBrowserProperties.java
@@ -1,6 +1,5 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.external.development.devutils.diskstorebrowser;
 
-import org.apache.wicket.devutils.diskstore.DiskStoreBrowserPage;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = DiskStoreBrowserProperties.PROPERTY_PREFIX)
@@ -9,7 +8,7 @@ public class DiskStoreBrowserProperties {
 	public static final String PROPERTY_PREFIX = "wicket.external.development.devutils.diskstorebrowser";
 	
 	/**
-	 * If enabled the {@link DiskStoreBrowserPage} should be mounted test page.
+	 * If enabled the {@link org.apache.wicket.markup.html.pages.BrowserInfoPage} should be mounted test page.
 	 * 
 	 * It is required that the deployment configuration is set to DEVELOPMENT.
 	 */

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/cassandra/DataStoreCassandraConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/cassandra/DataStoreCassandraConfig.java
@@ -1,7 +1,7 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.stuff.datastore.cassandra;
 
 import org.apache.wicket.DefaultPageManagerProvider;
-import org.apache.wicket.pageStore.IDataStore;
+import org.apache.wicket.pageStore.IPageStore;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -57,9 +57,10 @@ public class DataStoreCassandraConfig implements WicketApplicationInitConfigurat
 
 		webApplication.setPageManagerProvider(new DefaultPageManagerProvider(webApplication) {
 			@Override
-			protected IDataStore newDataStore() {
-				return new SessionQuotaManagingDataStore(new CassandraDataStore(settings),
-						TypeParser.parse(prop.getSessionSize(), prop.getSessionUnit()));
+			protected IPageStore newSessionStore(final IPageStore pageStore) {
+				CassandraDataStore delegate = new CassandraDataStore(webApplication.getName(), settings);
+				return new SessionQuotaManagingDataStore(delegate,
+					TypeParser.parse(prop.getSessionSize(), prop.getSessionUnit()));
 			}
 		});
 		

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/hazelcast/DataStoreHazelcastConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/hazelcast/DataStoreHazelcastConfig.java
@@ -1,7 +1,7 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.stuff.datastore.hazelcast;
 
 import org.apache.wicket.DefaultPageManagerProvider;
-import org.apache.wicket.pageStore.IDataStore;
+import org.apache.wicket.pageStore.IPageStore;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -56,8 +56,8 @@ public class DataStoreHazelcastConfig implements WicketApplicationInitConfigurat
 		
 		webApplication.setPageManagerProvider(new DefaultPageManagerProvider(webApplication) {
 			@Override
-			protected IDataStore newDataStore() {
-				HazelcastDataStore hazelcastDataStore = new HazelcastDataStore(hazelcastInstance);
+			protected IPageStore newSessionStore(final IPageStore pageStore) {
+				HazelcastDataStore hazelcastDataStore = new HazelcastDataStore(webApplication.getName(), hazelcastInstance);
 				return new SessionQuotaManagingDataStore(hazelcastDataStore, TypeParser.parse(prop.getSessionSize(), prop.getSessionUnit()));
 			}
 		});

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/redis/DataStoreRedisConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/configuration/extensions/stuff/datastore/redis/DataStoreRedisConfig.java
@@ -1,7 +1,7 @@
 package com.giffing.wicket.spring.boot.starter.configuration.extensions.stuff.datastore.redis;
 
 import org.apache.wicket.DefaultPageManagerProvider;
-import org.apache.wicket.pageStore.IDataStore;
+import org.apache.wicket.pageStore.IPageStore;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -53,13 +53,14 @@ public class DataStoreRedisConfig implements WicketApplicationInitConfiguration 
 	public void init(WebApplication webApplication) {
 		
 		webApplication.setPageManagerProvider(new DefaultPageManagerProvider(webApplication) {
-			protected IDataStore newDataStore() {
+			@Override
+			protected IPageStore newSessionStore(final IPageStore pageStore) {
 				IRedisSettings settings = new RedisSettings();
 				settings.setHostname(prop.getHostname());
 				settings.setPort(prop.getPort());
 				settings.setRecordTtl(TypeParser.parse(prop.getRecordTtl(), prop.getRecordTtlUnit()));
-				
-				RedisDataStore redisDataStore = new RedisDataStore(settings );
+
+				RedisDataStore redisDataStore = new RedisDataStore(webApplication.getName(), settings);
 				return new SessionQuotaManagingDataStore(redisDataStore, TypeParser.parse(prop.getSessionSize(), prop.getSessionUnit()));
 			}
 		});

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;


### PR DESCRIPTION
Closes https://github.com/MarcGiffing/wicket-spring-boot/issues/159

- This pull request updates the Apache Wicket version to 9.0.0-M3
- The most important changes to review are those that construct instances of session store.
- The changes are partially tested with Apache Syncope.
- JDK 11 is required for projects that build on Apache Wicket v9