### PR TITLE
Upgrade to Wicket 8.6.1, Wicketstuff 8.6.0 and Spring Boot 2.2.2.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.2.2.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<apache-shiro.version>1.4.0</apache-shiro.version>
-		<wicket.version>8.4.0</wicket.version>
+		<wicket.version>8.6.1</wicket.version>
+		<wicketstuff.version>8.6.0</wicketstuff.version>
 	</properties>
 
 	<dependencyManagement>
@@ -104,12 +105,12 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-annotation</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-htmlcompressor</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency> <!-- required for the wicketstuff-htmlcompressor -->
 				<groupId>com.yahoo.platform.yui</groupId>
@@ -119,27 +120,27 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-serializer-kryo2</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-serializer-fast2</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-restannotations</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-restannotations-json</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-springreference</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff.htmlvalidator</groupId>
@@ -149,7 +150,7 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-jamon</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 
 			<!-- Wicket other dependencies -->
@@ -167,27 +168,27 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-common</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-cassandra</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-hazelcast</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-memcached</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-datastore-redis</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<!-- Wicket websockets -->
 			<dependency>
@@ -210,7 +211,7 @@
 			<dependency>
 				<groupId>org.wicketstuff</groupId>
 				<artifactId>wicketstuff-shiro</artifactId>
-				<version>${wicket.version}</version>
+				<version>${wicketstuff.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.shiro</groupId>

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/jpa/support/CustomSimpleJpaRepository.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/jpa/support/CustomSimpleJpaRepository.java
@@ -8,7 +8,6 @@ import javax.persistence.TypedQuery;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.repository.NoRepositoryBean;

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/DefaultRepositoryService.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/DefaultRepositoryService.java
@@ -13,7 +13,7 @@ public abstract class DefaultRepositoryService<MODEL, ID, FILTER extends Filter>
 		Sort sort = Sort.unsorted();
 		if(filter.sort() != null){
 			Direction direction = filter.isAscending() ? Direction.ASC : Direction.DESC;
-			sort = new Sort(direction, filter.sort().getFieldName());
+			sort = Sort.by(direction, filter.sort().getFieldName());
 		}
 		return sort;
 	}

--- a/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/customer/CustomerRepositoryServiceImpl.java
+++ b/wicket-spring-boot-starter-example/src/main/java/com/giffing/wicket/spring/boot/example/repository/services/customer/CustomerRepositoryServiceImpl.java
@@ -15,7 +15,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,10 +75,10 @@ public class CustomerRepositoryServiceImpl extends DefaultRepositoryService<Cust
 			specs.add(CustomerSpecs.hasActive(filter.isActive()));
 		}
 		
-		Specifications<Customer> spec = null;
+		Specification<Customer> spec = null;
 		for (Specification<Customer> specification : specs) {
 			if(spec == null){
-				spec = Specifications.where(specification);
+				spec = Specification.where(specification);
 			}else {
 				spec = spec.and(specification);
 			}


### PR DESCRIPTION
Upgraded Wicket to version 8.6.1 and Wicketstuff libraries to 8.6.0. As there is no 8.6.1 version of Wicketstuff available, I introduced a new variable in the pom for the Wicketstuff version.
I also upgraded Spring Boot to 2.2.2.RELEASE and fixed compile errors.