### PR TITLE
Improve WicketWebInitializer (Wicket 8)

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
@@ -1,28 +1,19 @@
 package com.giffing.wicket.spring.boot.starter.web;
 
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-
-import org.apache.wicket.protocol.http.WicketFilter;
-import org.apache.wicket.spring.SpringWebApplicationFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.servlet.ServletContextInitializer;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketAutoConfig;
 import com.giffing.wicket.spring.boot.context.extensions.boot.actuator.WicketEndpointRepository;
 import com.giffing.wicket.spring.boot.starter.app.WicketBootWebApplication;
 import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerAutoConfig;
 import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerConfig;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.EnumSet;
 
 /**
  * Primary container configuration to configure Wicket requests.
@@ -32,52 +23,36 @@ import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerCon
 @Configuration
 @Import(value = { WicketWebInitializerAutoConfig.class })
 @EnableConfigurationProperties({ WicketWebInitializerProperties.class })
-public class WicketWebInitializer implements ServletContextInitializer {
+public class WicketWebInitializer {
 
 	public static final String WICKET_FILTERNAME = "wicket-filter";
-	
-	@Autowired
-	private ApplicationContext applicationContext; 
-	
-	@Autowired
-	private WicketWebInitializerConfig wicketWebInitializerConfig;
 
-	@Autowired
-	private WicketWebInitializerProperties props;
-	
-	@Autowired
-	private WicketEndpointRepository wicketEndpointRepository;
+	@Bean
+	public FilterRegistrationBean<WicketFilter> wicketFilter(
+			WicketWebInitializerConfig wicketWebInitializerConfig,
+			WicketWebInitializerProperties props,
+			WicketEndpointRepository wicketEndpointRepository,
+			WicketBootWebApplication wicketBootWebApplication
+	) {
+		WicketFilter wicketFilter = wicketWebInitializerConfig.createWicketFilter((WebApplication) wicketBootWebApplication);
 
-	@Override
-	public void onStartup(ServletContext servletContext) throws ServletException {
-		
-		String[] beanNamesForType = applicationContext.getBeanNamesForType(WicketBootWebApplication.class);
-		if(beanNamesForType.length != 1){
-			throw new IllegalStateException("Could not find exactly one bean for type WicketBootWebApplication " + beanNamesForType.length);
-		}
-		
-		FilterRegistration filter = servletContext.addFilter(WICKET_FILTERNAME, wicketWebInitializerConfig.filterClass());
+		FilterRegistrationBean<WicketFilter> filter = new FilterRegistrationBean<>(wicketFilter);
+		filter.setName(WICKET_FILTERNAME);
+		filter.addUrlPatterns(props.getFilterMappingParam());
+		filter.setDispatcherTypes(EnumSet.copyOf( props.getDispatcherTypes() ));
+		filter.setMatchAfter(props.isFilterMatchAfter());
 
-		// Spring configuration
-		filter.setInitParameter(WicketFilter.APP_FACT_PARAM, SpringWebApplicationFactory.class.getName());
-		filter.setInitParameter("applicationBean", beanNamesForType[0]);
+		filter.addInitParameter(WicketFilter.FILTER_MAPPING_PARAM, props.getFilterMappingParam());
+		props.getInitParameters().forEach(filter::addInitParameter);
 
-		filter.setInitParameter(WicketFilter.FILTER_MAPPING_PARAM, props.getFilterMappingParam());
-		filter.addMappingForUrlPatterns(EnumSet.copyOf( props.getDispatcherTypes() ), props.isFilterMatchAfter(), props.getFilterMappingParam());
-
-		Map<String, String> initParameters = props.getInitParameters();
-		for (Entry<String, String> initParam : initParameters.entrySet()) {
-			filter.setInitParameter(initParam.getKey(), initParam.getValue());
-		}
-		
-		
 		wicketEndpointRepository.add(new WicketAutoConfig.Builder(this.getClass())
 				.withDetail("wicketFilterName", WICKET_FILTERNAME)
-				.withDetail("wicketFilterClass", wicketWebInitializerConfig.filterClass())
+				.withDetail("wicketFilterClass", wicketFilter.getClass())
 				.withDetail("properties", props)
 				.build());
-		
-		
+
+		return filter;
 	}
 
 }
+

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializer.java
@@ -63,7 +63,7 @@ public class WicketWebInitializer implements ServletContextInitializer {
 		filter.setInitParameter("applicationBean", beanNamesForType[0]);
 
 		filter.setInitParameter(WicketFilter.FILTER_MAPPING_PARAM, props.getFilterMappingParam());
-		filter.addMappingForUrlPatterns(EnumSet.copyOf( props.getDispatcherTypes() ), false, props.getFilterMappingParam());
+		filter.addMappingForUrlPatterns(EnumSet.copyOf( props.getDispatcherTypes() ), props.isFilterMatchAfter(), props.getFilterMappingParam());
 
 		Map<String, String> initParameters = props.getInitParameters();
 		for (Entry<String, String> initParam : initParameters.entrySet()) {

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializerProperties.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializerProperties.java
@@ -16,7 +16,7 @@ public class WicketWebInitializerProperties {
 	
 	private String filterMappingParam = "/*";
 	
-	//Adds posibility to add init parameters dynamically
+	// Adds possibility to add init parameters dynamically
 	private Map<String, String> initParameters = new HashMap<>(); 
 
 	private List<DispatcherType> dispatcherTypes = Arrays.asList( DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.ASYNC );

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializerProperties.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/WicketWebInitializerProperties.java
@@ -21,6 +21,8 @@ public class WicketWebInitializerProperties {
 
 	private List<DispatcherType> dispatcherTypes = Arrays.asList( DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.ASYNC );
 
+	private boolean filterMatchAfter;
+
 	public String getFilterMappingParam() {
 		return filterMappingParam;
 	}
@@ -43,5 +45,13 @@ public class WicketWebInitializerProperties {
 
 	public void setDispatcherTypes(List<DispatcherType> dispatcherTypes) {
 		this.dispatcherTypes = dispatcherTypes;
+	}
+
+	public boolean isFilterMatchAfter() {
+		return filterMatchAfter;
+	}
+
+	public void setFilterMatchAfter(boolean filterMatchAfter) {
+		this.filterMatchAfter = filterMatchAfter;
 	}
 }

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/config/WicketWebInitializerConfig.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/config/WicketWebInitializerConfig.java
@@ -1,8 +1,8 @@
 package com.giffing.wicket.spring.boot.starter.web.config;
 
-import javax.servlet.Filter;
-
 import com.giffing.wicket.spring.boot.starter.web.WicketWebInitializer;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
 
 /**
  * Dynamic configuration support which will be used in {@link WicketWebInitializer}.
@@ -15,8 +15,8 @@ import com.giffing.wicket.spring.boot.starter.web.WicketWebInitializer;
 public interface WicketWebInitializerConfig {
 	
 	/**
-	 * @return a filter class which will be configured in the {@link WicketWebInitializer}
+	 * @return a {@link WicketFilter} which will be configured in the {@link WicketWebInitializer}
 	 */
-	public Class<? extends Filter> filterClass();
+	WicketFilter createWicketFilter(WebApplication application);
 	
 }

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/standard/StandardWicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/standard/StandardWicketWebInitializer.java
@@ -1,10 +1,8 @@
 package com.giffing.wicket.spring.boot.starter.web.servlet.standard;
 
-import javax.servlet.Filter;
-
-import org.apache.wicket.protocol.http.WicketFilter;
-
 import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerConfig;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
 
 /**
  * The {@link StandardWicketWebInitializer} will be configured when no other 
@@ -15,8 +13,8 @@ import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerCon
 public class StandardWicketWebInitializer implements WicketWebInitializerConfig {
 
 	@Override
-	public Class<? extends Filter> filterClass() {
-		return WicketFilter.class;
+	public WicketFilter createWicketFilter(WebApplication application) {
+		return new WicketFilter(application);
 	}
 
 }

--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/websocket/WebSocketWicketWebInitializer.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/websocket/WebSocketWicketWebInitializer.java
@@ -1,10 +1,9 @@
 package com.giffing.wicket.spring.boot.starter.web.servlet.websocket;
 
-import javax.servlet.Filter;
-
-import org.apache.wicket.protocol.ws.javax.JavaxWebSocketFilter;
-
 import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerConfig;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.protocol.http.WicketFilter;
+import org.apache.wicket.protocol.ws.javax.JavaxWebSocketFilter;
 
 /**
  * This initializer will be used if the JSR 356 - Java API for WebSocket is
@@ -13,9 +12,10 @@ import com.giffing.wicket.spring.boot.starter.web.config.WicketWebInitializerCon
  * @author Marc Giffing
  */
 public class WebSocketWicketWebInitializer implements WicketWebInitializerConfig {
-	
+
 	@Override
-	public Class<? extends Filter> filterClass() {
-		return JavaxWebSocketFilter.class;
+	public WicketFilter createWicketFilter(WebApplication application) {
+		return new JavaxWebSocketFilter(application);
 	}
+
 }


### PR DESCRIPTION
We are using Wicket 8 (still stuck on Java 8, but will change soon) and we are thankfully using your great library to integrate with Spring Boot. We have experienced that there are some problems when we want to deploy the application on a Glassfish/Payara 4 environment.

Problem here is that we experienced that a Glassfish/Payara bug reverses filter registration order if `matchAfter` is set to false. Thus we would appreciate if it is configurable.

We further refactored the Bean creation process so that it is more Spring-idiomatic. I hope you like it!