### PR TITLE
Issue #201 - WebSocketMessageSenderDefault.sendTo() fails when no Wicket application is bound to the current thread

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/websocket/WebSocketMessageSenderDefault.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/web/servlet/websocket/WebSocketMessageSenderDefault.java
@@ -34,11 +34,12 @@ public class WebSocketMessageSenderDefault implements WebSocketMessageBroadcaste
 		}
 	}
 	
-	public void sendTo(Object identifier, IWebSocketPushMessage event) {
+	@Override
+    public void sendTo(Object identifier, IWebSocketPushMessage event) {
 		if(identifier == null) {
 			return;
 		}
-		Application application = Application.get();
+
 		WebSocketSettings webSocketSettings = WebSocketSettings.Holder.get(application);
 		IWebSocketConnectionRegistry connectionRegistry = webSocketSettings.getConnectionRegistry();
 		wicketSessionResolver.resolve(identifier).forEach(sessionId -> {
@@ -49,5 +50,4 @@ public class WebSocketMessageSenderDefault implements WebSocketMessageBroadcaste
 			}
 		});
 	}
-
 }


### PR DESCRIPTION
- Use the application passed to the constructor instead of the thread-bound application