### PR TITLE
Fix error message when there are multiple sign in pages annotated #207

### DIFF
--- a/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootSecuredWebApplication.java
+++ b/wicket-spring-boot-starter/src/main/java/com/giffing/wicket/spring/boot/starter/app/WicketBootSecuredWebApplication.java
@@ -98,12 +98,12 @@ public class WicketBootSecuredWebApplication extends AuthenticatedWebApplication
 	@Override
 	protected Class<? extends WebPage> getSignInPageClass() {
 		if(classCandidates.getSignInPageCandidates().size() <= 0){
-			throw new IllegalStateException("Couln't find sign in page - please annotate the sign in page with @" + WicketSignInPage.class.getName());
+			throw new IllegalStateException("Couldn't find sign in page - please annotate the sign in page with @" + WicketSignInPage.class.getName());
 		}
 		if(classCandidates.getSignInPageCandidates().size() > 1 ){
 			String message = "Multiple sign in pages found - please annotate exactly one class with @" + WicketSignInPage.class.getName();
 			message += "\n";
-			for(WicketClassCandidate<Page> classCandidate : classCandidates.getHomePageCandidates()) {
+			for (WicketClassCandidate<WebPage> classCandidate : classCandidates.getSignInPageCandidates()) {
 				message += "\t" + classCandidate.getCandidate() + "\n";
 			}
 			throw new IllegalStateException(message);
@@ -117,7 +117,7 @@ public class WicketBootSecuredWebApplication extends AuthenticatedWebApplication
 	@Override
 	public Class<? extends Page> getHomePage() {
 		if(classCandidates.getHomePageCandidates().size() <= 0){
-			throw new IllegalStateException("Couln't find home page - please annotate the home page with @" + WicketHomePage.class.getName());
+			throw new IllegalStateException("Couldn't find home page - please annotate the home page with @" + WicketHomePage.class.getName());
 		}
 		if(classCandidates.getHomePageCandidates().size() > 1 ){
 			String message = "Multiple home pages found - please annotate exactly one class with @" + WicketHomePage.class.getName();
@@ -155,5 +155,4 @@ public class WicketBootSecuredWebApplication extends AuthenticatedWebApplication
 	public void setConfigurations(List<WicketApplicationInitConfiguration> configurations) {
 		this.configurations = configurations;
 	}
-	
 }


### PR DESCRIPTION
This change should fix the list of candidates found when there are more than one sign-in pages found.